### PR TITLE
Add Chief Entertainment Officer to team.md

### DIFF
--- a/docs/governance/team.md
+++ b/docs/governance/team.md
@@ -95,6 +95,12 @@
 - GitHub: [@github_username]
 - LinkedIn: [LinkedIn Profile URL]
 - Twitter: [@twitter_handle]
+
+### Chief Entertainment Officer
+- Name: [Full Name]
+- GitHub: [@github_username]
+- LinkedIn: [LinkedIn Profile URL]
+- Twitter: [@twitter_handle]
   
 ## Advisory Council
 


### PR DESCRIPTION
Add a new section for the Chief Entertainment Officer in the `docs/governance/team.md` file.

* **Community and Outreach Division**
  - Add a new section for the Chief Entertainment Officer.
  - List the Chief Entertainment Officer's name, GitHub username, LinkedIn profile URL, and Twitter handle.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/ruvnet/aihl?shareId=43c6f413-0034-42e9-a0e9-4a3bf1cbb7d0).